### PR TITLE
Migrating navigation to SwitUIRouter

### DIFF
--- a/whatToWatch.xcodeproj/project.pbxproj
+++ b/whatToWatch.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		28D7095729132C290008A96D /* AlertToast in Frameworks */ = {isa = PBXBuildFile; productRef = 28D7095629132C290008A96D /* AlertToast */; };
 		28D70959291344680008A96D /* RoundedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D70958291344680008A96D /* RoundedButton.swift */; };
 		28D7095B2913481C0008A96D /* PlexClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D7095A2913481C0008A96D /* PlexClient.swift */; };
+		28DAC105291B4B0900590ED0 /* SwiftUIRouter in Frameworks */ = {isa = PBXBuildFile; productRef = 28DAC104291B4B0900590ED0 /* SwiftUIRouter */; };
 		28ECF2EF2919ADA9008A4E57 /* ServerSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28ECF2EE2919ADA9008A4E57 /* ServerSelectionView.swift */; };
 /* End PBXBuildFile section */
 
@@ -46,6 +47,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				280343FB291311EA00D48005 /* PlexKit in Frameworks */,
+				28DAC105291B4B0900590ED0 /* SwiftUIRouter in Frameworks */,
 				28D7095729132C290008A96D /* AlertToast in Frameworks */,
 				28B3A9332919F4860033CE65 /* CardStack in Frameworks */,
 			);
@@ -134,6 +136,7 @@
 				280343FA291311EA00D48005 /* PlexKit */,
 				28D7095629132C290008A96D /* AlertToast */,
 				28B3A9322919F4860033CE65 /* CardStack */,
+				28DAC104291B4B0900590ED0 /* SwiftUIRouter */,
 			);
 			productName = whatToWatch;
 			productReference = 280343E82913117900D48005 /* whatToWatch.app */;
@@ -167,6 +170,7 @@
 				280343F9291311EA00D48005 /* XCRemoteSwiftPackageReference "PlexKit" */,
 				28D7095529132C290008A96D /* XCRemoteSwiftPackageReference "AlertToast" */,
 				28B3A9312919F4860033CE65 /* XCRemoteSwiftPackageReference "SwiftUI-CardStackView" */,
+				28DAC103291B4B0900590ED0 /* XCRemoteSwiftPackageReference "SwiftUIRouter" */,
 			);
 			productRefGroup = 280343E92913117900D48005 /* Products */;
 			projectDirPath = "";
@@ -431,6 +435,14 @@
 				minimumVersion = 1.3.7;
 			};
 		};
+		28DAC103291B4B0900590ED0 /* XCRemoteSwiftPackageReference "SwiftUIRouter" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/frzi/SwiftUIRouter";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.3.2;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -448,6 +460,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 28D7095529132C290008A96D /* XCRemoteSwiftPackageReference "AlertToast" */;
 			productName = AlertToast;
+		};
+		28DAC104291B4B0900590ED0 /* SwiftUIRouter */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 28DAC103291B4B0900590ED0 /* XCRemoteSwiftPackageReference "SwiftUIRouter" */;
+			productName = SwiftUIRouter;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/whatToWatch.xcodeproj/project.pbxproj
+++ b/whatToWatch.xcodeproj/project.pbxproj
@@ -13,7 +13,7 @@
 		280343FB291311EA00D48005 /* PlexKit in Frameworks */ = {isa = PBXBuildFile; productRef = 280343FA291311EA00D48005 /* PlexKit */; };
 		280343FE291312EC00D48005 /* SignInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 280343FD291312EC00D48005 /* SignInView.swift */; };
 		28B3A9332919F4860033CE65 /* CardStack in Frameworks */ = {isa = PBXBuildFile; productRef = 28B3A9322919F4860033CE65 /* CardStack */; };
-		28B3A9352919F4A10033CE65 /* MovieSwipeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B3A9342919F4A10033CE65 /* MovieSwipeView.swift */; };
+		28B3A9352919F4A10033CE65 /* MovieView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B3A9342919F4A10033CE65 /* MovieView.swift */; };
 		28B3A9372919F6340033CE65 /* MovieCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B3A9362919F6340033CE65 /* MovieCard.swift */; };
 		28C590732919B381000D91B2 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C590722919B381000D91B2 /* ContentView.swift */; };
 		28C590752919C22C000D91B2 /* LibrarySelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C590742919C22C000D91B2 /* LibrarySelectionView.swift */; };
@@ -31,7 +31,7 @@
 		280343EF2913117A00D48005 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		280343F22913117A00D48005 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		280343FD291312EC00D48005 /* SignInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInView.swift; sourceTree = "<group>"; };
-		28B3A9342919F4A10033CE65 /* MovieSwipeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieSwipeView.swift; sourceTree = "<group>"; };
+		28B3A9342919F4A10033CE65 /* MovieView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieView.swift; sourceTree = "<group>"; };
 		28B3A9362919F6340033CE65 /* MovieCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieCard.swift; sourceTree = "<group>"; };
 		28C590722919B381000D91B2 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		28C590742919C22C000D91B2 /* LibrarySelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibrarySelectionView.swift; sourceTree = "<group>"; };
@@ -104,7 +104,7 @@
 				28ECF2EE2919ADA9008A4E57 /* ServerSelectionView.swift */,
 				28C590722919B381000D91B2 /* ContentView.swift */,
 				28C590742919C22C000D91B2 /* LibrarySelectionView.swift */,
-				28B3A9342919F4A10033CE65 /* MovieSwipeView.swift */,
+				28B3A9342919F4A10033CE65 /* MovieView.swift */,
 				28DAC106291B4B6700590ED0 /* RootView.swift */,
 			);
 			path = Views;
@@ -203,7 +203,7 @@
 			files = (
 				28D7095B2913481C0008A96D /* PlexClient.swift in Sources */,
 				280343FE291312EC00D48005 /* SignInView.swift in Sources */,
-				28B3A9352919F4A10033CE65 /* MovieSwipeView.swift in Sources */,
+				28B3A9352919F4A10033CE65 /* MovieView.swift in Sources */,
 				28C590732919B381000D91B2 /* ContentView.swift in Sources */,
 				28DAC107291B4B6700590ED0 /* RootView.swift in Sources */,
 				28ECF2EF2919ADA9008A4E57 /* ServerSelectionView.swift in Sources */,

--- a/whatToWatch.xcodeproj/project.pbxproj
+++ b/whatToWatch.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		280343F32913117A00D48005 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 280343F22913117A00D48005 /* Preview Assets.xcassets */; };
 		280343FB291311EA00D48005 /* PlexKit in Frameworks */ = {isa = PBXBuildFile; productRef = 280343FA291311EA00D48005 /* PlexKit */; };
 		280343FE291312EC00D48005 /* SignInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 280343FD291312EC00D48005 /* SignInView.swift */; };
+		2869B141291BE21F00B4463C /* RootSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2869B140291BE21F00B4463C /* RootSelectionView.swift */; };
 		28B3A9332919F4860033CE65 /* CardStack in Frameworks */ = {isa = PBXBuildFile; productRef = 28B3A9322919F4860033CE65 /* CardStack */; };
 		28B3A9352919F4A10033CE65 /* MovieView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B3A9342919F4A10033CE65 /* MovieView.swift */; };
 		28B3A9372919F6340033CE65 /* MovieCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B3A9362919F6340033CE65 /* MovieCard.swift */; };
@@ -31,6 +32,7 @@
 		280343EF2913117A00D48005 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		280343F22913117A00D48005 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		280343FD291312EC00D48005 /* SignInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInView.swift; sourceTree = "<group>"; };
+		2869B140291BE21F00B4463C /* RootSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootSelectionView.swift; sourceTree = "<group>"; };
 		28B3A9342919F4A10033CE65 /* MovieView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieView.swift; sourceTree = "<group>"; };
 		28B3A9362919F6340033CE65 /* MovieCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieCard.swift; sourceTree = "<group>"; };
 		28C590722919B381000D91B2 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -106,6 +108,7 @@
 				28C590742919C22C000D91B2 /* LibrarySelectionView.swift */,
 				28B3A9342919F4A10033CE65 /* MovieView.swift */,
 				28DAC106291B4B6700590ED0 /* RootView.swift */,
+				2869B140291BE21F00B4463C /* RootSelectionView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -211,6 +214,7 @@
 				28D70959291344680008A96D /* RoundedButton.swift in Sources */,
 				280343EC2913117900D48005 /* whatToWatchApp.swift in Sources */,
 				28B3A9372919F6340033CE65 /* MovieCard.swift in Sources */,
+				2869B141291BE21F00B4463C /* RootSelectionView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/whatToWatch.xcodeproj/project.pbxproj
+++ b/whatToWatch.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		28D70959291344680008A96D /* RoundedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D70958291344680008A96D /* RoundedButton.swift */; };
 		28D7095B2913481C0008A96D /* PlexClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D7095A2913481C0008A96D /* PlexClient.swift */; };
 		28DAC105291B4B0900590ED0 /* SwiftUIRouter in Frameworks */ = {isa = PBXBuildFile; productRef = 28DAC104291B4B0900590ED0 /* SwiftUIRouter */; };
+		28DAC107291B4B6700590ED0 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28DAC106291B4B6700590ED0 /* RootView.swift */; };
 		28ECF2EF2919ADA9008A4E57 /* ServerSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28ECF2EE2919ADA9008A4E57 /* ServerSelectionView.swift */; };
 /* End PBXBuildFile section */
 
@@ -38,6 +39,7 @@
 		28D7095A2913481C0008A96D /* PlexClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlexClient.swift; sourceTree = "<group>"; };
 		28D70961291362A60008A96D /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		28D70962291364250008A96D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		28DAC106291B4B6700590ED0 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		28ECF2EE2919ADA9008A4E57 /* ServerSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerSelectionView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -103,6 +105,7 @@
 				28C590722919B381000D91B2 /* ContentView.swift */,
 				28C590742919C22C000D91B2 /* LibrarySelectionView.swift */,
 				28B3A9342919F4A10033CE65 /* MovieSwipeView.swift */,
+				28DAC106291B4B6700590ED0 /* RootView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -202,6 +205,7 @@
 				280343FE291312EC00D48005 /* SignInView.swift in Sources */,
 				28B3A9352919F4A10033CE65 /* MovieSwipeView.swift in Sources */,
 				28C590732919B381000D91B2 /* ContentView.swift in Sources */,
+				28DAC107291B4B6700590ED0 /* RootView.swift in Sources */,
 				28ECF2EF2919ADA9008A4E57 /* ServerSelectionView.swift in Sources */,
 				28C590752919C22C000D91B2 /* LibrarySelectionView.swift in Sources */,
 				28D70959291344680008A96D /* RoundedButton.swift in Sources */,

--- a/whatToWatch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/whatToWatch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -35,6 +35,15 @@
         "revision" : "9b45ef54b9e7bfbee46fe4a5982ecf449ac2b47c",
         "version" : "0.0.6"
       }
+    },
+    {
+      "identity" : "swiftuirouter",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/frzi/SwiftUIRouter",
+      "state" : {
+        "revision" : "cd8c2bb32019082075456afa9521ec3ec7499ffa",
+        "version" : "1.3.2"
+      }
     }
   ],
   "version" : 2

--- a/whatToWatch/PlexClient.swift
+++ b/whatToWatch/PlexClient.swift
@@ -51,6 +51,7 @@ class PlexClient: ObservableObject {
     @Published var client: Plex
     @Published var user: PlexUser?
     private var serverUrl = ""
+    private(set) var selectedLibrary: PlexLibrary?
     
     // MARK: - Functions.
     /// Creates and configures the `Plex` object to be used for requests.
@@ -216,5 +217,11 @@ class PlexClient: ObservableObject {
             return
         }
         serverUrl = server.connections[0].uri
+    }
+    
+    /// Saves a reference to the given `PlexLibrary` for future use.
+    /// - Parameter library: The `PlexLibrary` reference to be saved.
+    func saveLibrarySelection(_ library: PlexLibrary) {
+        selectedLibrary = library
     }
 }

--- a/whatToWatch/Views/LibrarySelectionView.swift
+++ b/whatToWatch/Views/LibrarySelectionView.swift
@@ -6,12 +6,14 @@
 //
 
 import SwiftUI
+import SwiftUIRouter
 import PlexKit
 import AlertToast
 
 struct LibrarySelectionView: View {
     // MARK: - Properties.
     @EnvironmentObject private var plexClient: PlexClient
+    @EnvironmentObject private var navigator: Navigator
     @State private var libraries: [PlexLibrary]?
     @State private var toastShowing = false
     @State private var toastSubTitle = ""
@@ -29,8 +31,9 @@ struct LibrarySelectionView: View {
                 Text("There must be a load of movies somewhere. Time to pick what library you want to watch from.")
                     .padding(.bottom, 30)
                 ForEach(libraries!, id: \.title!) { library in
-                    NavigationLink(destination: MovieSwipeView(library: library)) {
-                        RoundedButton(title: library.title ?? "Unnamed Library")
+                    RoundedTapButton(title: library.title ?? "Unnamed Library") {
+                        plexClient.saveLibrarySelection(library)
+                        navigator.navigate("/movies", replace: true)
                     }
                 }
             }

--- a/whatToWatch/Views/MovieView.swift
+++ b/whatToWatch/Views/MovieView.swift
@@ -1,5 +1,5 @@
 //
-//  MovieSwipeView.swift
+//  MovieView.swift
 //  whatToWatch
 //
 //  Created by Alex Loren on 11/7/22.
@@ -9,7 +9,7 @@ import SwiftUI
 import PlexKit
 import CardStack
 
-struct MovieSwipeView: View {
+struct MovieView: View {
     // MARK: - Properties
     @EnvironmentObject private var plexClient: PlexClient
     @State private var movies: [PlexMediaItem]?
@@ -37,11 +37,13 @@ struct MovieSwipeView: View {
                         Text("The time has come, start swiping! You know the drill. Once there has been a match with everyone else, we will let you know which movie was chosen!")
                             .padding(.bottom, 30)
                     }
+                    
                     CardStack(direction: LeftRight.direction, data: movies!, id: \.key, onSwipe: { movie, direction in
                         print("Swiped \(movie.title!) to \(direction)")
                     }, content: { movie, _, _ in
                         MovieCard(movie: movie)
                     })
+                    .environment(\.cardStackConfiguration, CardStackConfiguration(maxVisibleCards: 2, swipeThreshold: 0.35, animation: .easeInOut))
                 }
             }
         }
@@ -67,6 +69,6 @@ struct MovieSwipeView: View {
 
 struct MovieSwipeView_Previews: PreviewProvider {
     static var previews: some View {
-        MovieSwipeView(library: nil)
+        MovieView(library: nil)
     }
 }

--- a/whatToWatch/Views/RootSelectionView.swift
+++ b/whatToWatch/Views/RootSelectionView.swift
@@ -1,0 +1,26 @@
+//
+//  RootSelectionView.swift
+//  whatToWatch
+//
+//  Created by Alex Loren on 11/9/22.
+//
+
+import SwiftUI
+
+struct RootSelectionView: View {
+    // MARK: - Properties
+    @EnvironmentObject private var plexClient: PlexClient
+    
+    // MARK: - View declaration.
+    var body: some View {
+        NavigationStack {
+            ServerSelectionView()
+        }
+    }
+}
+
+struct RootSelectionView_Previews: PreviewProvider {
+    static var previews: some View {
+        RootSelectionView()
+    }
+}

--- a/whatToWatch/Views/RootView.swift
+++ b/whatToWatch/Views/RootView.swift
@@ -16,6 +16,18 @@ struct RootView: View {
     // MARK: - View declaration.
     var body: some View {
         SwitchRoutes {
+            Route("movies") {
+                if plexClient.selectedLibrary == nil {
+                    Navigate(to: "selections", replace: true)
+                } else {
+                    MovieView(library: plexClient.selectedLibrary!)
+                        .environmentObject(plexClient)
+                }
+            }
+            Route("selections") {
+                RootSelectionView()
+                    .environmentObject(plexClient)
+            }
             Route {
                 SignInView()
                     .environmentObject(plexClient)

--- a/whatToWatch/Views/RootView.swift
+++ b/whatToWatch/Views/RootView.swift
@@ -1,0 +1,31 @@
+//
+//  RootView.swift
+//  whatToWatch
+//
+//  Created by Alex Loren on 11/8/22.
+//
+
+import SwiftUI
+import SwiftUIRouter
+
+struct RootView: View {
+    // MARK: - Properties.
+    @EnvironmentObject private var navigator: Navigator
+    private let plexClient = PlexClient()
+    
+    // MARK: - View declaration.
+    var body: some View {
+        SwitchRoutes {
+            Route {
+                SignInView()
+                    .environmentObject(plexClient)
+            }
+        }
+    }
+}
+
+struct RootView_Previews: PreviewProvider {
+    static var previews: some View {
+        RootView()
+    }
+}

--- a/whatToWatch/Views/SignInView.swift
+++ b/whatToWatch/Views/SignInView.swift
@@ -6,11 +6,13 @@
 //
 
 import SwiftUI
+import SwiftUIRouter
 import AlertToast
 
 struct SignInView: View {
     // MARK: - Properties.
     @EnvironmentObject private var plexClient: PlexClient
+    @EnvironmentObject private var navigator: Navigator
     @FocusState private var focused: Fields?
     @State private var username = ""
     @State private var password = ""
@@ -74,7 +76,7 @@ struct SignInView: View {
                 plexClient.signIn(username: username, password: password) { result in
                     switch result {
                     case .success(_):
-                        print("Successfully signed in!")
+                        navigator.navigate("/selections", replace: true)
                     case .failure(let error):
                         toastType = .error(.red)
                         toastTitle = "Sign-in error!"

--- a/whatToWatch/whatToWatchApp.swift
+++ b/whatToWatch/whatToWatchApp.swift
@@ -6,17 +6,16 @@
 //
 
 import SwiftUI
+import SwiftUIRouter
 
 @main
 struct whatToWatchApp: App {
-    // MARK: - Properties.
-    private let plexClient = PlexClient()
-    
     // MARK: - View declaration.
     var body: some Scene {
         WindowGroup {
-            ContentView()
-                .environmentObject(plexClient)
+            Router {
+                RootView()
+            }
         }
     }
 }


### PR DESCRIPTION
Migrated the navigation in the app to [frzi/SwiftUIRouter](https://github.com/frzi/SwiftUIRouter) from an overarching `NavigationStack`. A `NavigationStack` is still used in placed where the users might want to go back and forth in the stack, such as server selection to library and back.